### PR TITLE
Use OPAM2 on CI

### DIFF
--- a/.travis-Dockerfile.template
+++ b/.travis-Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine_ocaml-%ocaml_version%
+FROM ocaml/opam2:alpine
 
 WORKDIR /home/opam/satysfi-external-repo
 COPY . .
@@ -6,15 +6,13 @@ COPY . .
 ENV OPAMYES "true"
 # Enable/disable tests (see `opam install --help`)
 ENV OPAMBUILDTEST %opambuildtest%
-# Note that ocaml/opam uses a local opam-repository instead of the online one
-# Copying is a workaround. It's unnecessary if using OPAM 2.
 RUN set -ex \
- && cd /home/opam/ \
- && cp -r satysfi-external-repo satysfi-external-repo2 \
  && cd /home/opam/opam-repository \
  && git pull --quiet origin master \
- && cd /home/opam/satysfi-external-repo2 \
+ && cd /home/opam/satysfi-external-repo \
  && ls \
+ && opam switch %ocaml_version% \
+ && eval $(opam env) \
  && opam repository add satysfi-external . \
  && opam update \
  && opam depext --update %package% \

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ env:
     - OPAMBUILDTEST="true"
   matrix:
     # Note that PRE_INSTALL_HOOK assumes that PACKAGE contains its version.
-    - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.05"
     - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.06"
-    - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.05"
     - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.06"
+    - PACKAGE="otfm.0.3.1+satysfi" OCAML_VERSION="4.06"
+    - PACKAGE="otfm.0.3.2+satysfi" OCAML_VERSION="4.06"
+    - PACKAGE="yojson.1.4.1+satysfi" OCAML_VERSION="4.06"
 install:
   - DOCKERFILE=".travis-Dockerfile.template"
   - sed -i "s/%ocaml_version%/${OCAML_VERSION}/g" "${DOCKERFILE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Install and test each package on a Docker image ocaml/opam:alpine_ocaml-<version>
+# Install and test each package on a Docker image ocaml/opam2:alpine
 
 language: c
 sudo: required
@@ -9,10 +9,10 @@ env:
     - OPAMBUILDTEST="true"
   matrix:
     # Note that PRE_INSTALL_HOOK assumes that PACKAGE contains its version.
-    - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.05.0"
-    - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.06.0"
-    - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.05.0"
-    - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.06.0"
+    - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.05"
+    - PACKAGE="camlpdf.2.2.1+satysfi" OCAML_VERSION="4.06"
+    - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.05"
+    - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.06"
 install:
   - DOCKERFILE=".travis-Dockerfile.template"
   - sed -i "s/%ocaml_version%/${OCAML_VERSION}/g" "${DOCKERFILE}"


### PR DESCRIPTION
Currently CI testing fails because it uses OPAM1 and default OPAM repository is written in OPAM2 format now.

So this PR changes CI to use OPAM2. Additionally, this updates packages to test.