### PR TITLE
add satyrographos.0.0.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - PACKAGE="otfm.0.3.0+satysfi" OCAML_VERSION="4.06"
     - PACKAGE="otfm.0.3.1+satysfi" OCAML_VERSION="4.06"
     - PACKAGE="otfm.0.3.2+satysfi" OCAML_VERSION="4.06"
+    - PACKAGE="satyrographos.0.0.1.3" OCAML_VERSION="4.06"
     - PACKAGE="yojson.1.4.1+satysfi" OCAML_VERSION="4.06"
 install:
   - DOCKERFILE=".travis-Dockerfile.template"

--- a/packages/satyrographos/satyrographos.0.0.1.3/opam
+++ b/packages/satyrographos/satyrographos.0.0.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "satyrographos"
+version: "0.0.1.3"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL3+"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "cmdliner"
+  "core"
+  "dune" {build}
+  "fileutils"
+  "json-derivers"
+  "ppx_deriving" {build}
+  "ppx_inline_test" {build}
+  "ppx_jane" {build}
+  "uri" {>= "2.0.0"}
+  "yojson"
+]
+synopsis: "A naive package manager for SATySFi"
+description: """
+Satyrographos is a naive package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src: "https://github.com/na4zagin3/satyrographos/archive/v0.0.1.3.tar.gz"
+  checksum: [
+    "sha256=f01fb92b71d73c02ea71f87ead01fb21220a8eca04f0888700f6e229708be500"
+    "sha512=91793516a910fa6fcc59e76e452853b378e129b165a30ca658e94b87c79d096269206bfae7ce7686cfa7ef3697e6964fdf98937bf31581b042bd90aca9da8078"
+  ]
+}


### PR DESCRIPTION
This PR adds Satyrographos v0.0.1.3.

Satyrographos provides basic package management where a package of a satysfi library is treated as an opam package.
It does copy files under `$(opam config var share)/satysfi/<package>` to `~/.satysfi/dist` (a default value; the destination is configurable), composing hash files.

See https://github.com/na4zagin3/satyrographos for details.