### PR TITLE
yojson-with-position.1.4.2+satysfi requires dune 2.0

### DIFF
--- a/packages/yojson-with-position/yojson-with-position.1.4.2+satysfi/opam
+++ b/packages/yojson-with-position/yojson-with-position.1.4.2+satysfi/opam
@@ -19,7 +19,7 @@ build-test: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune" {build & >= "2.0"}
   "cppo" {build}
   "easy-format"
   "biniou" {>= "1.2.0"}


### PR DESCRIPTION
yojson-with-position.1.4.2+satysfi actually requires Dune 2.0 or later.  It should be declared at the dependency section.